### PR TITLE
A few more assertions

### DIFF
--- a/documentation/assertions/moment/to-be-between.md
+++ b/documentation/assertions/moment/to-be-between.md
@@ -1,8 +1,16 @@
 Passes if the moment instance is between two other given instances, both extremes included.
 
 ```js
-expect(moment(), 'to be between', moment().startOf('day'), moment().endOf('day'))
+expect(moment(0), 'to be between', moment(0), moment(10))
 ```
+
+To exclude the end-points from being valid values, use
+
+```js
+expect(moment(), 'to be between exclusively', moment().startOf('day'), moment().endOf('day'))
+```
+
+Failing assertions gives the following:
 
 ```js
 expect(moment('2015-01-01'), 'to be between', moment('2015-02-01'), moment('2015-03-01'));

--- a/documentation/assertions/moment/to-be-between.md
+++ b/documentation/assertions/moment/to-be-between.md
@@ -1,0 +1,14 @@
+Passes if the moment instance is between two other given instances, both extremes included.
+
+```js
+expect(moment(), 'to be between', moment().startOf('day'), moment().endOf('day'))
+```
+
+```js
+expect(moment('2015-01-01'), 'to be between', moment('2015-02-01'), moment('2015-03-01'));
+```
+
+```output
+expected moment(2015-01-01T00:00:00.000+01:00)
+to be between moment(2015-02-01T00:00:00.000+01:00) and moment(2015-03-01T00:00:00.000+01:00)
+```

--- a/documentation/assertions/moment/to-be-between.md
+++ b/documentation/assertions/moment/to-be-between.md
@@ -7,7 +7,7 @@ expect(moment(0), 'to be between', moment(0), moment(10))
 To exclude the end-points from being valid values, use
 
 ```js
-expect(moment(), 'to be between exclusively', moment().startOf('day'), moment().endOf('day'))
+expect(moment(), 'to be exclusively between', moment().startOf('day'), moment().endOf('day'))
 ```
 
 Failing assertions gives the following:

--- a/documentation/assertions/moment/to-be-between.md
+++ b/documentation/assertions/moment/to-be-between.md
@@ -1,13 +1,13 @@
-Passes if the moment instance is between two other given instances, both extremes included.
+Passes if the moment instance is between two other given instances:
 
 ```js
-expect(moment(0), 'to be between', moment(0), moment(10))
+expect(moment(), 'to be between', moment().startOf('day'), moment().endOf('day'))
 ```
 
-To exclude the end-points from being valid values, use
+To include the end-points as valid values, use
 
 ```js
-expect(moment(), 'to be exclusively between', moment().startOf('day'), moment().endOf('day'))
+expect(moment(0), 'to be inclusively between', moment(0), moment(10))
 ```
 
 Failing assertions gives the following:

--- a/documentation/assertions/moment/to-be-same-or-after.md
+++ b/documentation/assertions/moment/to-be-same-or-after.md
@@ -1,0 +1,18 @@
+Passes if the moment instance represents a time at or later than the specified time.
+
+```js
+expect(moment(), 'to be same or after', moment().subtract(1, 'hour'));
+```
+
+It supports any value supported by [moment#isAfter](http://momentjs.com/docs/#/query/is-after/)
+
+When the assertion fails you'll get this output:
+
+```js
+expect(moment('2015-02-03'), 'to be same or after', moment('2015-04-03'));
+```
+
+```output
+expected moment(2015-02-03T00:00:00.000+01:00)
+to be same or after moment(2015-04-03T00:00:00.000+02:00)
+```

--- a/documentation/assertions/moment/to-be-same-or-before.md
+++ b/documentation/assertions/moment/to-be-same-or-before.md
@@ -1,0 +1,18 @@
+Passes if the moment instance represents a time at or before the specified time.
+
+```js
+expect(moment(), 'to be same or before', moment().add(1, 'hour'));
+```
+
+It supports any value supported by [moment#isAfter](http://momentjs.com/docs/#/query/is-after/)
+
+When the assertion fails you'll get this output:
+
+```js
+expect(moment('2015-04-01'), 'to be same or before', moment('2015-01-01'));
+```
+
+```output
+expected moment(2015-04-01T00:00:00.000+02:00)
+to be same or before moment(2015-01-01T00:00:00.000+01:00)
+```

--- a/lib/unexpected-moment.js
+++ b/lib/unexpected-moment.js
@@ -58,6 +58,14 @@
                 expect(subject.isSame(value) || subject.isAfter(value), '[not] to be true');
             });
 
+            expect.addAssertion('<moment> [not] to be between <any> <any>', function (expect, subject, from, to) {
+                expect.argsOutput = function (output) {
+                    output.appendInspected(from).text(' and ').appendInspected(to);
+                };
+
+                expect(subject.isBetween(from, to) || subject.isSame(from) || subject.isSame(to), '[not] to be true');
+            });
+
             expect.addAssertion('<moment> when formatted with <string> <assertion>', function (expect, subject, format) {
                 return expect.shift(subject.format(format));
             });

--- a/lib/unexpected-moment.js
+++ b/lib/unexpected-moment.js
@@ -58,12 +58,18 @@
                 expect(subject.isSame(value) || subject.isAfter(value), '[not] to be true');
             });
 
-            expect.addAssertion('<moment> [not] to be between <any> <any>', function (expect, subject, from, to) {
+            expect.addAssertion('<moment> [not] to be between [exclusively] <any> <any>', function (expect, subject, from, to) {
                 expect.argsOutput = function (output) {
                     output.appendInspected(from).text(' and ').appendInspected(to);
                 };
 
-                expect(subject.isBetween(from, to) || subject.isSame(from) || subject.isSame(to), '[not] to be true');
+                var result = subject.isBetween(from, to);
+
+                if (!expect.flags.exclusively) {
+                    result = result || subject.isSame(from) || subject.isSame(to);
+                }
+
+                expect(result, '[not] to be true');
             });
 
             expect.addAssertion('<moment> when formatted with <string> <assertion>', function (expect, subject, format) {

--- a/lib/unexpected-moment.js
+++ b/lib/unexpected-moment.js
@@ -58,14 +58,14 @@
                 expect(subject.isSame(value) || subject.isAfter(value), '[not] to be true');
             });
 
-            expect.addAssertion('<moment> [not] to be [exclusively] between <any> <any>', function (expect, subject, from, to) {
+            expect.addAssertion('<moment> [not] to be [inclusively] between <any> <any>', function (expect, subject, from, to) {
                 expect.argsOutput = function (output) {
                     output.appendInspected(from).text(' and ').appendInspected(to);
                 };
 
                 var result = subject.isBetween(from, to);
 
-                if (!expect.flags.exclusively) {
+                if (expect.flags.inclusively) {
                     result = result || subject.isSame(from) || subject.isSame(to);
                 }
 

--- a/lib/unexpected-moment.js
+++ b/lib/unexpected-moment.js
@@ -58,7 +58,7 @@
                 expect(subject.isSame(value) || subject.isAfter(value), '[not] to be true');
             });
 
-            expect.addAssertion('<moment> [not] to be between [exclusively] <any> <any>', function (expect, subject, from, to) {
+            expect.addAssertion('<moment> [not] to be [exclusively] between <any> <any>', function (expect, subject, from, to) {
                 expect.argsOutput = function (output) {
                     output.appendInspected(from).text(' and ').appendInspected(to);
                 };

--- a/lib/unexpected-moment.js
+++ b/lib/unexpected-moment.js
@@ -48,6 +48,16 @@
                 expect(subject.isAfter(value), '[not] to be true');
             });
 
+            expect.addAssertion('<moment> [not] to be same or before <any>', function (expect, subject, value) {
+                //expect(subject.isSameOrBefore(value), '[not] to be true');
+                expect(subject.isSame(value) || subject.isBefore(value), '[not] to be true');
+            });
+
+            expect.addAssertion('<moment> [not] to be same or after <any>', function (expect, subject, value) {
+                //expect(subject.isSameOrAfter(value), '[not] to be true');
+                expect(subject.isSame(value) || subject.isAfter(value), '[not] to be true');
+            });
+
             expect.addAssertion('<moment> when formatted with <string> <assertion>', function (expect, subject, format) {
                 return expect.shift(subject.format(format));
             });

--- a/test/unexpected-moment.spec.js
+++ b/test/unexpected-moment.spec.js
@@ -154,8 +154,8 @@ describe('unexpected-moment', function () {
         expect(moment(1), 'not to be between', moment(2), moment(2));
 
         // Exclusivity
-        expect(moment(0), 'not to be between exclusively', moment(0), moment(1));
-        expect(moment(1), 'to be between exclusively', moment(0), moment(2));
+        expect(moment(0), 'not to be exclusively between', moment(0), moment(1));
+        expect(moment(1), 'to be exclusively between', moment(0), moment(2));
     });
 
     it('allows formatting moments asserting against expected string outputs', function () {

--- a/test/unexpected-moment.spec.js
+++ b/test/unexpected-moment.spec.js
@@ -144,18 +144,15 @@ describe('unexpected-moment', function () {
     });
 
     it('identifies moments between other moments', function () {
-        expect(moment(0), 'to be between', moment(0), moment(0));
-
-        expect(moment(0), 'to be between', moment(0), moment(2));
+        expect(moment(0), 'not to be between', moment(0), moment(2));
         expect(moment(1), 'to be between', moment(0), moment(2));
-        expect(moment(2), 'to be between', moment(0), moment(2));
+        expect(moment(2), 'not to be between', moment(0), moment(2));
 
-        expect(moment(1), 'not to be between', moment(0), moment(0));
-        expect(moment(1), 'not to be between', moment(2), moment(2));
-
-        // Exclusivity
-        expect(moment(0), 'not to be exclusively between', moment(0), moment(1));
-        expect(moment(1), 'to be exclusively between', moment(0), moment(2));
+        // Inclusivity
+        expect(moment(0), 'not to be inclusively between', moment(1), moment(2));
+        expect(moment(1), 'to be inclusively between', moment(1), moment(2));
+        expect(moment(2), 'to be inclusively between', moment(1), moment(2));
+        expect(moment(3), 'not to be inclusively between', moment(1), moment(2));
     });
 
     it('allows formatting moments asserting against expected string outputs', function () {

--- a/test/unexpected-moment.spec.js
+++ b/test/unexpected-moment.spec.js
@@ -90,6 +90,59 @@ describe('unexpected-moment', function () {
         expect(moment(0), 'not to be after', moment(1).toObject());
     });
 
+    it('identifies a moment that occurs at same time or before another chronologically', function () {
+        expect(moment(0), 'to be same or before', moment(1));
+        expect(moment(0), 'to be same or before', moment(1).toISOString());
+        expect(moment(0), 'to be same or before', moment(1).toArray());
+        expect(moment(0), 'to be same or before', moment(1).toDate());
+        expect(moment(0), 'to be same or before', moment(1).valueOf());
+        expect(moment(0), 'to be same or before', moment(1).toObject());
+
+        expect(moment(1), 'not to be same or before', moment(0));
+        expect(moment(1), 'not to be same or before', moment(0).toISOString());
+        expect(moment(1), 'not to be same or before', moment(0).toArray());
+        expect(moment(1), 'not to be same or before', moment(0).toDate());
+        expect(moment(1), 'not to be same or before', moment(0).valueOf());
+        expect(moment(1), 'not to be same or before', moment(0).toObject());
+
+        expect(moment(0), 'to be same or before', moment(0));
+        expect(moment(0), 'to be same or before', moment(0).toISOString());
+        expect(moment(0), 'to be same or before', moment(0).toArray());
+        expect(moment(0), 'to be same or before', moment(0).toDate());
+        expect(moment(0), 'to be same or before', moment(0).valueOf());
+        expect(moment(0), 'to be same or before', moment(0).toObject());
+
+        expect(moment(1), 'not to be same or before', moment(0));
+        expect(moment(1), 'not to be same or before', moment(0).toISOString());
+        expect(moment(1), 'not to be same or before', moment(0).toArray());
+        expect(moment(1), 'not to be same or before', moment(0).toDate());
+        expect(moment(1), 'not to be same or before', moment(0).valueOf());
+        expect(moment(1), 'not to be same or before', moment(0).toObject());
+    });
+
+    it('identifies a moment that occurs at same time or after chronologically', function () {
+        expect(moment(1), 'to be same or after', moment(0));
+        expect(moment(1), 'to be same or after', moment(0).toISOString());
+        expect(moment(1), 'to be same or after', moment(0).toArray());
+        expect(moment(1), 'to be same or after', moment(0).toDate());
+        expect(moment(1), 'to be same or after', moment(0).valueOf());
+        expect(moment(1), 'to be same or after', moment(0).toObject());
+
+        expect(moment(0), 'not to be same or after', moment(1));
+        expect(moment(0), 'not to be same or after', moment(1).toISOString());
+        expect(moment(0), 'not to be same or after', moment(1).toArray());
+        expect(moment(0), 'not to be same or after', moment(1).toDate());
+        expect(moment(0), 'not to be same or after', moment(1).valueOf());
+        expect(moment(0), 'not to be same or after', moment(1).toObject());
+
+        expect(moment(0), 'to be same or after', moment(0));
+        expect(moment(0), 'to be same or after', moment(0).toISOString());
+        expect(moment(0), 'to be same or after', moment(0).toArray());
+        expect(moment(0), 'to be same or after', moment(0).toDate());
+        expect(moment(0), 'to be same or after', moment(0).valueOf());
+        expect(moment(0), 'to be same or after', moment(0).toObject());
+    });
+
     it('allows formatting moments asserting against expected string outputs', function () {
         expect(moment(1), 'when formatted with', 'YYYY', 'to be', '1970');
         expect(moment(1), 'when formatted with', 'YYYY', 'to equal', '1970');

--- a/test/unexpected-moment.spec.js
+++ b/test/unexpected-moment.spec.js
@@ -143,6 +143,17 @@ describe('unexpected-moment', function () {
         expect(moment(0), 'to be same or after', moment(0).toObject());
     });
 
+    it('identifies moments between other moments', function () {
+        expect(moment(0), 'to be between', moment(0), moment(0));
+
+        expect(moment(0), 'to be between', moment(0), moment(2));
+        expect(moment(1), 'to be between', moment(0), moment(2));
+        expect(moment(2), 'to be between', moment(0), moment(2));
+
+        expect(moment(1), 'not to be between', moment(0), moment(0));
+        expect(moment(1), 'not to be between', moment(2), moment(2));
+    });
+
     it('allows formatting moments asserting against expected string outputs', function () {
         expect(moment(1), 'when formatted with', 'YYYY', 'to be', '1970');
         expect(moment(1), 'when formatted with', 'YYYY', 'to equal', '1970');

--- a/test/unexpected-moment.spec.js
+++ b/test/unexpected-moment.spec.js
@@ -152,6 +152,10 @@ describe('unexpected-moment', function () {
 
         expect(moment(1), 'not to be between', moment(0), moment(0));
         expect(moment(1), 'not to be between', moment(2), moment(2));
+
+        // Exclusivity
+        expect(moment(0), 'not to be between exclusively', moment(0), moment(1));
+        expect(moment(1), 'to be between exclusively', moment(0), moment(2));
     });
 
     it('allows formatting moments asserting against expected string outputs', function () {


### PR DESCRIPTION
    [not] to be same or before <any>
    [not] to be same of after <any>
    [not] to be between <any> <any>

Considerations
* `to be between` includes `from` and `to`, if 100% correct, it should be `to be between, both inclusive`. But typing that out doesn't seem natural with unexpected and I can't readily come up with something better.
* More modern versions of moment has `isSameOr{before,after}(other)`, but .. backwards compatibility and all.